### PR TITLE
Fix compilation error on MacOS

### DIFF
--- a/dissertation.cls
+++ b/dissertation.cls
@@ -12,6 +12,8 @@
 \LoadClass[10pt]{book}
 
 %% Import packages
+\RequirePackage{fontspec}
+\defaultfontfeatures{Extension = .otf}
 \RequirePackage{fontawesome}
 \RequirePackage{amsmath}
 \RequirePackage{amssymb}

--- a/propositions.cls
+++ b/propositions.cls
@@ -11,6 +11,8 @@
 
 \LoadClass[10pt]{book}
 
+\RequirePackage{fontspec}
+\defaultfontfeatures{Extension = .otf}
 \RequirePackage{fontawesome}
 \RequirePackage{amsmath}
 \RequirePackage{amssymb}


### PR DESCRIPTION
Without these additions, xelatex fails to find fontawesome on MacOS.

